### PR TITLE
collaspse transitive deps by default

### DIFF
--- a/cmd/stree/cli/json.go
+++ b/cmd/stree/cli/json.go
@@ -18,10 +18,10 @@ func Json() *cobra.Command {
 		Example: ` tree json [--out <path>] <json file>
 
 	# create a tree directory like structure for the provided json
-	tree json example-sca.json
+	stree json example-sca.json
 
 	# create a tree directory like structure for the provided json and output into provided file
-	tree json -o <output-new-file.json>  example-sca.json
+	stree json -o <output-new-file.json>  example-sca.json
 
 		
 		`,

--- a/cmd/stree/cli/json/json.go
+++ b/cmd/stree/cli/json/json.go
@@ -2,7 +2,7 @@ package json
 
 import (
 	"fmt"
-	"log"
+	"os"
 
 	"github.com/rivo/tview"
 	"github.com/viveksahu26/stree/cmd/stree/cli/options"
@@ -11,18 +11,43 @@ import (
 
 func JsonCmd(jo options.JsonOptions, args []string) error {
 	fileName := args[0]
-	fmt.Println("fileName: ", fileName)
 	doesNodenameToBeShort := jo.Name
+
 	root, err := tjson.ParseJSON(fileName)
 	if err != nil {
-		fmt.Println("Error parsing JSON:", err)
-		return err
+		return fmt.Errorf("parsing JSON: %w", err)
+	}
+	if root.Name == "" && len(root.Children) == 0 {
+		return fmt.Errorf("empty or invalid JSON structure in %s", fileName)
 	}
 
-	rootNode := tjson.BuildTreeNode(root, 0, doesNodenameToBeShort)
-	treeView := tview.NewTreeView().SetRoot(rootNode).SetCurrentNode(rootNode)
+	// Print text-based tree if no output file or UI-only mode
+	if jo.Out == "" {
+		fmt.Print(tjson.PrintTree(root, "", true))
+	}
 
-	app := tview.NewApplication()
+	// Save to output file if specified
+	if jo.Out != "" {
+		output := tjson.PrintTree(root, "", true)
+		if err := os.WriteFile(jo.Out, []byte(output), 0o644); err != nil {
+			return fmt.Errorf("writing output to %s: %w", jo.Out, err)
+		}
+		return nil
+	}
+
+	// Build interactive UI
+	rootNode := tjson.BuildTreeNode(root, 0, doesNodenameToBeShort)
+
+	// Explicitly collapse all nodes (except root)
+	rootNode.CollapseAll()
+	rootNode.SetExpanded(true) // Keep root expanded to show direct dependencies
+
+	treeView := tview.
+		NewTreeView().
+		SetRoot(rootNode).
+		SetCurrentNode(rootNode)
+
+	// Handle node selection (click or Enter) to toggle expansion
 	treeView.SetSelectedFunc(func(node *tview.TreeNode) {
 		if node.IsExpanded() {
 			node.Collapse()
@@ -31,8 +56,14 @@ func JsonCmd(jo options.JsonOptions, args []string) error {
 		}
 	})
 
-	if err := app.SetRoot(treeView, true).Run(); err != nil {
-		log.Fatalf("Error running application: %v\n", err)
+	// Add title bar
+	flex := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(tview.NewTextView().SetText(fmt.Sprintf("Dependency Tree: %s (Ctrl+Q to quit)", fileName)), 1, 1, false).
+		AddItem(treeView, 0, 1, true)
+
+	app := tview.NewApplication()
+	if err := app.SetRoot(flex, true).Run(); err != nil {
+		return fmt.Errorf("running application: %w", err)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/gdamore/encoding v1.0.0 // indirect
+	github.com/gdamore/tcell v1.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,16 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
+github.com/gdamore/tcell v1.4.0 h1:vUnHwJRvcPQa3tzi+0QI4U9JINXYJlOz9yiaiPQ2wMU=
+github.com/gdamore/tcell v1.4.0/go.mod h1:vxEiSDZdW3L+Uhjii9c3375IlDmR05bzxY404ZVSMo0=
 github.com/gdamore/tcell/v2 v2.7.1 h1:TiCcmpWHiAU7F0rA2I3S2Y4mmLmO9KHxJ7E1QhYzQbc=
 github.com/gdamore/tcell/v2 v2.7.1/go.mod h1:dSXtXTSK0VsW1biw65DZLZ2NKr7j0qP/0J7ONmsraWg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/rivo/tview v0.0.0-20240921122403-a64fc48d7654 h1:oa+fljZiaJUVyiT7WgIM3OhirtwBm0LJA97LvWUlBu8=
@@ -33,6 +37,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/tjson/tjson.go
+++ b/pkg/tjson/tjson.go
@@ -70,6 +70,7 @@ func BuildTreeNode(pkg Package, depth int, doesNodenameToBeShort bool) *tview.Tr
 	if doesNodenameToBeShort {
 		nodeText = ShortName(nodeText)
 	}
+
 	color := colors[depth%len(colors)]
 
 	tv := tview.NewTreeNode(nodeText).SetColor(color)


### PR DESCRIPTION
This PR updates the following changes:
- collaspe the transitive deps by default, only direct deps will be shown by default.
- to see, deps of direct deps, press enter button.